### PR TITLE
sendgrid unique args and rails 2.3 fix

### DIFF
--- a/lib/sendgrid.rb
+++ b/lib/sendgrid.rb
@@ -133,32 +133,38 @@ module SendGrid
     @sg_unique_args = args
   end
 
-  # Sets the custom X-SMTPAPI header after creating the email but before delivery
-  # NOTE: This override is used for Rails 2 ActionMailer classes. 
-  def create!(method_name, *parameters)
-    super
-    if @sg_substitutions && !@sg_substitutions.empty?
-      @sg_substitutions.each do |find, replace|
-        raise ArgumentError.new("Array for #{find} is not the same size as the recipient array") if replace.size != @sg_recipients.size
+  # only override the appropriet methods for the current rails version
+  if Rails.version < '3.0.0'
+
+    # Sets the custom X-SMTPAPI header after creating the email but before delivery
+    # NOTE: This override is used for Rails 2 ActionMailer classes. 
+    def create!(method_name, *parameters)
+      super
+      if @sg_substitutions && !@sg_substitutions.empty?
+        @sg_substitutions.each do |find, replace|
+          raise ArgumentError.new("Array for #{find} is not the same size as the recipient array") if replace.size != @sg_recipients.size
+        end
       end
+      puts "SendGrid X-SMTPAPI: #{sendgrid_json_headers(mail)}" if Object.const_defined?("SENDGRID_DEBUG_OUTPUT") && SENDGRID_DEBUG_OUTPUT
+      @mail['X-SMTPAPI'] = sendgrid_json_headers(mail)
     end
-    puts "SendGrid X-SMTPAPI: #{sendgrid_json_headers(mail)}" if Object.const_defined?("SENDGRID_DEBUG_OUTPUT") && SENDGRID_DEBUG_OUTPUT
-    @mail['X-SMTPAPI'] = sendgrid_json_headers(mail)
-  end
-  
-  protected
-  
-  # Sets the custom X-SMTPAPI header after creating the email but before delivery
-  # NOTE: This override is used for Rails 3 ActionMailer classes.
-  def mail(headers={}, &block)
-    super
-    if @sg_substitutions && !@sg_substitutions.empty?
-      @sg_substitutions.each do |find, replace|
-        raise ArgumentError.new("Array for #{find} is not the same size as the recipient array") if replace.size != @sg_recipients.size
+
+  else
+
+    protected
+
+    # Sets the custom X-SMTPAPI header after creating the email but before delivery
+    # NOTE: This override is used for Rails 3 ActionMailer classes.
+    def mail(headers={}, &block)
+      super
+      if @sg_substitutions && !@sg_substitutions.empty?
+        @sg_substitutions.each do |find, replace|
+          raise ArgumentError.new("Array for #{find} is not the same size as the recipient array") if replace.size != @sg_recipients.size
+        end
       end
+      puts "SendGrid X-SMTPAPI: #{sendgrid_json_headers(message)}" if Object.const_defined?("SENDGRID_DEBUG_OUTPUT") && SENDGRID_DEBUG_OUTPUT
+      self.headers['X-SMTPAPI'] = sendgrid_json_headers(message)
     end
-    puts "SendGrid X-SMTPAPI: #{sendgrid_json_headers(message)}" if Object.const_defined?("SENDGRID_DEBUG_OUTPUT") && SENDGRID_DEBUG_OUTPUT
-    self.headers['X-SMTPAPI'] = sendgrid_json_headers(message)
   end
 
   private


### PR DESCRIPTION
added sendgrid_unique_args function to support unique_args per http://support.sendgrid.com/entries/353200-implementing-bounce-notification-for-multiple-from-addresses

Also added rails version check to determine which actionmailer override to use
