### PR TITLE
I ran into a problem when I upgraded to 1.0.1. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 coverage
 rdoc
 pkg
+
+.rvmrc

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
 gem "json"
+gem 'actionmailer'
 
 # Add dependencies required to use your gem here.
 # Example:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,58 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    abstract (1.0.0)
+    actionmailer (3.0.10)
+      actionpack (= 3.0.10)
+      mail (~> 2.2.19)
+    actionpack (3.0.10)
+      activemodel (= 3.0.10)
+      activesupport (= 3.0.10)
+      builder (~> 2.1.2)
+      erubis (~> 2.6.6)
+      i18n (~> 0.5.0)
+      rack (~> 1.2.1)
+      rack-mount (~> 0.6.14)
+      rack-test (~> 0.5.7)
+      tzinfo (~> 0.3.23)
+    activemodel (3.0.10)
+      activesupport (= 3.0.10)
+      builder (~> 2.1.2)
+      i18n (~> 0.5.0)
+    activesupport (3.0.10)
+    builder (2.1.2)
+    erubis (2.6.6)
+      abstract (>= 1.0.0)
     git (1.2.5)
+    i18n (0.5.0)
     jeweler (1.5.2)
       bundler (~> 1.0.0)
       git (>= 1.2.5)
       rake
     json (1.5.1)
+    mail (2.2.19)
+      activesupport (>= 2.3.6)
+      i18n (>= 0.4.0)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    mime-types (1.16)
+    polyglot (0.3.2)
+    rack (1.2.3)
+    rack-mount (0.6.14)
+      rack (>= 1.0.0)
+    rack-test (0.5.7)
+      rack (>= 1.0)
     rake (0.8.7)
+    treetop (1.4.10)
+      polyglot
+      polyglot (>= 0.3.1)
+    tzinfo (0.3.29)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionmailer
   bundler (~> 1.0.0)
   jeweler (~> 1.5.1)
   json

--- a/lib/sendgrid.rb
+++ b/lib/sendgrid.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'action_mailer'
 
 module SendGrid
 

--- a/sendgrid.gemspec
+++ b/sendgrid.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Stephen Blankenship"]
-  s.date = %q{2011-09-08}
+  s.date = %q{2011-09-22}
   s.description = %q{This gem allows simple integration between ActionMailer and SendGrid. 
                          SendGrid is an email deliverability API that is affordable and has lots of bells and whistles.}
   s.email = %q{stephenrb@gmail.com}
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   ]
   s.homepage = %q{http://github.com/stephenb/sendgrid}
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.3.6}
+  s.rubygems_version = %q{1.6.2}
   s.summary = %q{A gem that allows simple integration of ActionMailer with SendGrid (http://sendgrid.com)}
   s.test_files = [
     "test/sendgrid_test.rb",
@@ -40,22 +40,24 @@ Gem::Specification.new do |s|
   ]
 
   if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3
 
-    if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<json>, [">= 0"])
+      s.add_runtime_dependency(%q<actionmailer>, [">= 0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.1"])
       s.add_runtime_dependency(%q<json>, [">= 0"])
     else
       s.add_dependency(%q<json>, [">= 0"])
+      s.add_dependency(%q<actionmailer>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.5.1"])
       s.add_dependency(%q<json>, [">= 0"])
     end
   else
     s.add_dependency(%q<json>, [">= 0"])
+    s.add_dependency(%q<actionmailer>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.5.1"])
     s.add_dependency(%q<json>, [">= 0"])


### PR DESCRIPTION
I had to add a runtime depencency on ActionMailer since that library is being called directly from sendgrid.

updated Gemfile / gemspec to require action_mailer. updated lib/sendgrid.rb to requrie action_mailer
