### PR TITLE
.deliver

### DIFF
--- a/lib/sendgrid.rb
+++ b/lib/sendgrid.rb
@@ -141,29 +141,31 @@ module SendGrid
     # Sets the custom X-SMTPAPI header after creating the email but before delivery
     # NOTE: This override is used for Rails 3 ActionMailer classes.
     def mail(headers={}, &block)
-      super
-      if @sg_substitutions && !@sg_substitutions.empty?
-        @sg_substitutions.each do |find, replace|
-          raise ArgumentError.new("Array for #{find} is not the same size as the recipient array") if replace.size != @sg_recipients.size
+      super(headers, &block).tap
+        if @sg_substitutions && !@sg_substitutions.empty?
+          @sg_substitutions.each do |find, replace|
+            raise ArgumentError.new("Array for #{find} is not the same size as the recipient array") if replace.size != @sg_recipients.size
+          end
         end
+        puts "SendGrid X-SMTPAPI: #{sendgrid_json_headers(message)}" if Object.const_defined?("SENDGRID_DEBUG_OUTPUT") && SENDGRID_DEBUG_OUTPUT
+        self.headers['X-SMTPAPI'] = sendgrid_json_headers(message)
       end
-      puts "SendGrid X-SMTPAPI: #{sendgrid_json_headers(message)}" if Object.const_defined?("SENDGRID_DEBUG_OUTPUT") && SENDGRID_DEBUG_OUTPUT
-      self.headers['X-SMTPAPI'] = sendgrid_json_headers(message)
     end
 
   else
 
     # Sets the custom X-SMTPAPI header after creating the email but before delivery
-    # NOTE: This override is used for Rails 2 ActionMailer classes. 
+    # NOTE: This override is used for Rails 2 ActionMailer classes.
     def create!(method_name, *parameters)
-      super
-      if @sg_substitutions && !@sg_substitutions.empty?
-        @sg_substitutions.each do |find, replace|
-          raise ArgumentError.new("Array for #{find} is not the same size as the recipient array") if replace.size != @sg_recipients.size
+      super.tap do |mail|
+        if @sg_substitutions && !@sg_substitutions.empty?
+          @sg_substitutions.each do |find, replace|
+            raise ArgumentError.new("Array for #{find} is not the same size as the recipient array") if replace.size != @sg_recipients.size
+          end
         end
+        puts "SendGrid X-SMTPAPI: #{sendgrid_json_headers(mail)}" if Object.const_defined?("SENDGRID_DEBUG_OUTPUT") && SENDGRID_DEBUG_OUTPUT
+        @mail['X-SMTPAPI'] = sendgrid_json_headers(mail)
       end
-      puts "SendGrid X-SMTPAPI: #{sendgrid_json_headers(mail)}" if Object.const_defined?("SENDGRID_DEBUG_OUTPUT") && SENDGRID_DEBUG_OUTPUT
-      @mail['X-SMTPAPI'] = sendgrid_json_headers(mail)
     end
 
   end


### PR DESCRIPTION
This allows us to continue to do MailerClass.mailer_method.deliver

In rails 3 I was having trouble because `mail()` wans't returning a deliverable object. This fixes it (but I am not 100% sure about what I did to the rails2 version :)
