### PR TITLE
let mail() return a mailing object

### DIFF
--- a/lib/sendgrid.rb
+++ b/lib/sendgrid.rb
@@ -141,7 +141,7 @@ module SendGrid
     # Sets the custom X-SMTPAPI header after creating the email but before delivery
     # NOTE: This override is used for Rails 3 ActionMailer classes.
     def mail(headers={}, &block)
-      super
+      m = super
       if @sg_substitutions && !@sg_substitutions.empty?
         @sg_substitutions.each do |find, replace|
           raise ArgumentError.new("Array for #{find} is not the same size as the recipient array") if replace.size != @sg_recipients.size
@@ -149,6 +149,7 @@ module SendGrid
       end
       puts "SendGrid X-SMTPAPI: #{sendgrid_json_headers(message)}" if Object.const_defined?("SENDGRID_DEBUG_OUTPUT") && SENDGRID_DEBUG_OUTPUT
       self.headers['X-SMTPAPI'] = sendgrid_json_headers(message)
+      m
     end
 
   else


### PR DESCRIPTION
This allows us to continue to do MailerClass.mailer_method.deliver
