### PR TITLE
Allow unique args to be set at the class level

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,12 @@ gem "json"
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
-  # gem "shoulda", ">= 0"
+  gem "shoulda", ">= 0"
   gem "bundler", "~> 1.0.0"
   gem "jeweler", "~> 1.5.1"
   # gem "rcov", ">= 0"
+end
+
+group :test do
+  gem "actionmailer", ">= 2.3.2"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,67 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    actionmailer (3.1.5)
+      actionpack (= 3.1.5)
+      mail (~> 2.3.3)
+    actionpack (3.1.5)
+      activemodel (= 3.1.5)
+      activesupport (= 3.1.5)
+      builder (~> 3.0.0)
+      erubis (~> 2.7.0)
+      i18n (~> 0.6)
+      rack (~> 1.3.6)
+      rack-cache (~> 1.2)
+      rack-mount (~> 0.8.2)
+      rack-test (~> 0.6.1)
+      sprockets (~> 2.0.4)
+    activemodel (3.1.5)
+      activesupport (= 3.1.5)
+      builder (~> 3.0.0)
+      i18n (~> 0.6)
+    activesupport (3.1.5)
+      multi_json (>= 1.0, < 1.3)
+    builder (3.0.0)
+    erubis (2.7.0)
     git (1.2.5)
+    hike (1.2.1)
+    i18n (0.6.0)
     jeweler (1.5.2)
       bundler (~> 1.0.0)
       git (>= 1.2.5)
       rake
     json (1.5.1)
+    mail (2.3.3)
+      i18n (>= 0.4.0)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    mime-types (1.18)
+    multi_json (1.2.0)
+    polyglot (0.3.3)
+    rack (1.3.6)
+    rack-cache (1.2)
+      rack (>= 0.4)
+    rack-mount (0.8.3)
+      rack (>= 1.0.0)
+    rack-test (0.6.1)
+      rack (>= 1.0)
     rake (0.8.7)
+    shoulda (2.10.3)
+    sprockets (2.0.4)
+      hike (~> 1.2)
+      rack (~> 1.0)
+      tilt (~> 1.1, != 1.3.0)
+    tilt (1.3.3)
+    treetop (1.4.10)
+      polyglot
+      polyglot (>= 0.3.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionmailer (>= 2.3.2)
   bundler (~> 1.0.0)
   jeweler (~> 1.5.1)
   json
+  shoulda

--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ rescue LoadError
   end
 end
 
-task :test => :check_dependencies
+task :test
 
 task :default => :test
 

--- a/test/sendgrid_test.rb
+++ b/test/sendgrid_test.rb
@@ -1,7 +1,11 @@
 require 'test_helper'
 
 class SendgridTest < Test::Unit::TestCase
-  def setup    
+  def setup
+    ActionMailer::Base.delivery_method = :test
+    ActionMailer::Base.perform_deliveries = true
+    ActionMailer::Base.deliveries = []
+    
     @options = {
       :to => ['test@example.com'],
       :from => 'test@example.com',
@@ -18,7 +22,17 @@ class SendgridTest < Test::Unit::TestCase
   
   should "require the same number of items in a substitution array as is in the recipient array" do
     assert_raise ArgumentError do
-      test_email = SendgridCampaignTestMailer.create_test(@options)
+      test_email = SendgridCampaignTestMailer.create_test(@options).deliver
     end
+  end
+  
+  should "accept a hash of unique args at the class level" do
+    assert_equal ({ :test_arg => "test value" }), SendgridUniqueArgsMailer.default_sg_unique_args
+  end
+  
+  should "pass unique args from both the mailer class and the mailer method through custom headers" do
+    SendgridUniqueArgsMailer.unique_args_test_email(@options).deliver
+    mail = ActionMailer::Base.deliveries.last
+    assert_match ({ :mailer_method_unique_arg => "some value", :test_arg => "test value" }.to_json.gsub(/(["\]}])([,:])(["\[{])/, '\\1\\2 \\3')), mail.header['X-SMTPAPI'].value
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,11 +4,8 @@ require 'shoulda'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
-require 'sendgrid'
 require 'action_mailer'
-
-class Test::Unit::TestCase
-end
+require 'sendgrid'
 
 class SendgridCampaignTestMailer < ActionMailer::Base
   include SendGrid
@@ -26,13 +23,9 @@ class SendgridCampaignTestMailer < ActionMailer::Base
   # array must match the :to array
   # :category the sendgrid category used for tracking
   # :html_content, :text_content, :subject
-  def test(options)
+  def create_test(options)
     handle_sendgrid_options(options)
-    recipients(options[:to])
-    from(options[:from])
-    reply_to(options[:reply_to])
-    subject(options[:subject])
-    body(options[:html_content])
+    mail(options)
   end
   
   protected
@@ -49,7 +42,16 @@ class SendgridCampaignTestMailer < ActionMailer::Base
       end
     end
     
-
     sendgrid_category(options[:category])
+  end
+end
+
+class SendgridUniqueArgsMailer < ActionMailer::Base
+  include SendGrid
+  sendgrid_unique_args({ :test_arg => "test value" })
+  
+  def unique_args_test_email(options)
+    sendgrid_unique_args({ :mailer_method_unique_arg => "some value" })
+    mail(options)
   end
 end


### PR DESCRIPTION
I found this to be useful because the app I'm integrating with SendGrid has around seven mailers. To set it up as DRYly as possible, I created one main mailer that the others inherit from. Inside that mailer, I'm able to call sendgrid_category, sendgrid_enable, and now sendgrid_unique_args through a custom method_missing. This way, I can dynamically set my unique_args without having to put sendgrid_unique_args in each mailer method. The existing method-level implementation still plays nicely with the new class method.

I've added tests, and made a change or two to get the existing test suite running and passing. Cheers on the gem! Thanks a lot!
