### PR TITLE
Added a FIXME to mail method

### DIFF
--- a/lib/sendgrid.rb
+++ b/lib/sendgrid.rb
@@ -162,6 +162,8 @@ module SendGrid
 
   protected
 
+    # FIXME: There is an issue here, it's required to copy/paste this method in the class we are using to make
+    #        the gem works. Why? Issue tracker is missing too (in repository).
     # Sets the custom X-SMTPAPI header after creating the email but before delivery
     def mail(headers={}, &block)
       m = super


### PR DESCRIPTION
mail method doesn't override basic mail method (or similar issue), so the gem is entirely ignored (doesn't hook in any way to actionmailer)
