### PR TITLE
Use pretty JSON to reduce risk of going over 1k character per line limit

### DIFF
--- a/lib/sendgrid.rb
+++ b/lib/sendgrid.rb
@@ -254,7 +254,7 @@ module SendGrid
       header_opts[:filters] = filters if filters && !filters.empty?
     end
 
-    header_opts.to_json.gsub(/(["\]}])([,:])(["\[{])/, '\\1\\2 \\3')
+    JSON.pretty_generate(header_opts).gsub(/(["\]}])([,:])(["\[{])/, '\\1\\2 \\3')
   end
 
   def filters_hash_from_options(enabled_opts, disabled_opts)


### PR DESCRIPTION
According to [Sendgrid's SMTP API documentation](
https://sendgrid.com/docs/API_Reference/SMTP_API/using_the_smtp_api.html
# -Requirements-and-Limitations), all lines in a header must be under

1,000 characters. By using [`JSON.pretty_generate`](http://flori.github.io/json/doc/classes/JSON.html#method-i-pretty_generate), arrays (e.g. multiple recipients  and substitutions) will be wrapped, reducing the likelihood of exceeding this limit, with the exception being if some element in an array is itself over 1,000 characters long.
