### PR TITLE
Remove duplicate dependencies

### DIFF
--- a/sendgrid.gemspec
+++ b/sendgrid.gemspec
@@ -45,20 +45,17 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.1"])
-      s.add_runtime_dependency(%q<json>, [">= 0"])
     else
       s.add_dependency(%q<json>, [">= 0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.5.1"])
-      s.add_dependency(%q<json>, [">= 0"])
     end
   else
     s.add_dependency(%q<json>, [">= 0"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.5.1"])
-    s.add_dependency(%q<json>, [">= 0"])
   end
 end
 


### PR DESCRIPTION
Getting a warning from Bundler otherwise

```
The gemspec at /home/ruy/.rvm/gems/ruby-2.3.0/bundler/gems/sendgrid-e1bdb3170968/sendgrid.gemspec is not valid. The validation error was 'duplicate dependency on json (>= 0), (>= 0) use:
    add_runtime_dependency 'json', '>= 0', '>= 0'
```

Not very familiar with gem builing, but I believe this was added in error in https://github.com/stephenb/sendgrid/commit/425e6c2b4afc890c702bb76f8fdf2e9123b9dce8
