### PR TITLE
I change the port 25 to 578

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Example:
 
     ActionMailer::Base.smtp_settings = {
       :address => "smtp.sendgrid.net",
-      :port => 25,
+      :port => 587,
       :domain => "mysite.com",
       :authentication => :plain,
       :user_name => "sendgrd_username",


### PR DESCRIPTION
I changed the port 25 to 578 because some providers has blocked the port 25, so, the most part of the emails, they are not sent.

You can check here: https://sendgrid.com/docs/Integrate/index.html
