### PR TITLE
include batch_id header when sending emails

### DIFF
--- a/lib/sendgrid.rb
+++ b/lib/sendgrid.rb
@@ -28,7 +28,7 @@ module SendGrid
                       :default_footer_text, :default_spamcheck_score, :default_sg_unique_args
       end
       attr_accessor :sg_category, :sg_options, :sg_disabled_options, :sg_recipients, :sg_substitutions,
-                    :subscriptiontrack_text, :footer_text, :spamcheck_score, :sg_unique_args, :sg_send_at
+                    :subscriptiontrack_text, :footer_text, :spamcheck_score, :sg_unique_args, :sg_send_at, :sg_batch_id
     end
 
     # NOTE: This commented-out approach may be a "safer" option for Rails 3, but it
@@ -106,6 +106,11 @@ module SendGrid
   # Call within mailer method to set send time for this mail
   def sendgrid_send_at(utc_timestamp)
     @sg_send_at = utc_timestamp
+  end
+
+  # Call within mailer method to set send time for this mail
+  def sendgrid_batch_id(batch_id)
+    @sg_batch_id = batch_id
   end
 
   # Call within mailer method to set unique args for this email.
@@ -228,6 +233,7 @@ module SendGrid
 
     #Set send_at if set by the user
     header_opts[:send_at] = @sg_send_at unless @sg_send_at.blank?
+    header_opts[:batch_id] = @sg_batch_id unless @sg_batch_id.blank?
 
     # Set multi-recipients
     if @sg_recipients && !@sg_recipients.empty?


### PR DESCRIPTION
This PR includes the `batch_id` header, similar to `send_at`